### PR TITLE
[DOXIA-542] Markdown module converts all apostrophes to quotation marks

### DIFF
--- a/doxia-modules/doxia-module-markdown/src/it/general/src/site/markdown/quotes.md
+++ b/doxia-modules/doxia-module-markdown/src/it/general/src/site/markdown/quotes.md
@@ -1,0 +1,5 @@
+# Quotes
+
+This ain't a quote, but an apostrophe.
+
+This 'quoted text' isn't surrounded with apostrophes.

--- a/doxia-modules/doxia-module-markdown/src/it/general/src/site/site.xml
+++ b/doxia-modules/doxia-module-markdown/src/it/general/src/site/site.xml
@@ -29,6 +29,7 @@ under the License.
 
     <menu name="Testing">
       <item name="Metadata" href="metadata.html" />
+      <item name="Quotes" href="quotes.html" />
     </menu>
 
   </body>

--- a/doxia-modules/doxia-module-markdown/src/it/general/verify.groovy
+++ b/doxia-modules/doxia-module-markdown/src/it/general/verify.groovy
@@ -53,3 +53,13 @@ assert content =~ '<meta name="Empty" content="" />'
 // No description is provided, as it was not part of the metadata at the beginning of the doc
 assert !(content =~ '<meta name="description"')
 
+
+// Verify quotes.html
+
+resultFile = new File(basedir, "target/site/quotes.html")
+assert resultFile.isFile()
+
+content = resultFile.text;
+assert content =~ /This ain't a quote, but an apostrophe./
+assert content =~ /This &#x2018;quoted text&#x2019; isn't surrounded with apostrophes./
+

--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
@@ -143,6 +143,9 @@ public class MarkdownParser
                 StrikethroughExtension.create()
         ) );
 
+        // Disable wrong apostrophe replacement
+        flexmarkOptions.set( TypographicExtension.SINGLE_QUOTE_UNMATCHED, "&apos;" );
+
         // Additional options on the HTML rendering
         flexmarkOptions.set( HtmlRenderer.HTML_BLOCK_OPEN_TAG_EOL, false );
         flexmarkOptions.set( HtmlRenderer.HTML_BLOCK_CLOSE_TAG_EOL, false );

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownParserTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownParserTest.java
@@ -473,4 +473,27 @@ public class MarkdownParserTest
     {
         parseFileToEventTestingSink( "flex-384" );
     }
+
+    // Apostrophe versus single quotes
+    // Simple apostrophes (like in Sophie's Choice) must not be replaced with a single quote
+    public void testQuoteVsApostrophe()
+        throws Exception
+    {
+        List<SinkEventElement> eventList = parseFileToEventTestingSink( "quote-vs-apostrophe" ).getEventList();
+
+        StringBuilder content = new StringBuilder();
+        for ( SinkEventElement element : eventList )
+        {
+            if ( "text".equals(element.getName()) )
+            {
+                content.append( element.getArgs()[0] );
+            }
+        }
+        assertEquals(
+                "This apostrophe isn't a quote."
+                + "This \u2018quoted text\u2019 isn't surrounded by apostrophes.",
+                content.toString() );
+
+    }
+
 }

--- a/doxia-modules/doxia-module-markdown/src/test/resources/quote-vs-apostrophe.md
+++ b/doxia-modules/doxia-module-markdown/src/test/resources/quote-vs-apostrophe.md
@@ -1,0 +1,3 @@
+This apostrophe isn't a quote.
+
+This 'quoted text' isn't surrounded by apostrophes.


### PR DESCRIPTION
* Disable the replacement of apostrophes with stylized quotes
* Add corresponding unit tests and integration tests

This closes #50